### PR TITLE
Add docker configuration for different ROS distros

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,47 @@
+# Use the docker container to run HAROS
+
+Install docker https://docs.docker.com/install/linux/docker-ce/ubuntu/
+
+Build the HAROS docker image, for your desired ROS distro version:
+```
+cd path-to-make-haros-easy/docker
+[sudo] docker build --tag=haros_ROS_DISTRO -f ROS_DISTRO/Dockerfile .
+```
+
+This repository supports currently the following ROS versions:
+```
+[sudo] docker build --tag=haros_melodic -f melodic/Dockerfile .
+[sudo] docker build --tag=haros_noetic -f noetic/Dockerfile .
+[sudo] docker build --tag=foxy_noetic -f foxy/Dockerfile .
+```
+
+Run the image with the docker extractor script givig as argument the url of the GitHub repository that holds the source code and mounting the `index.yaml` file to its filesystem:
+
+Either
+```
+[sudo] docker run -it --mount type=bind,source=*Path to index.yaml*,target=/root/.haros/index.yaml -p 4000:4000 haros_ROS_DISTRO:latest /haros_call.sh *Repo URL*
+```
+
+or
+
+```
+[sudo] docker run -it -v *Path to index.yaml*:/root/.haros/index.yaml -p 4000:4000 haros_ROS_DISTRO:latest /haros_call.sh *Repo URL*
+```
+
+can be used.
+
+### Examples
+
+```
+cd path-to-make-haros-easy/docker
+[sudo] docker run -it --mount type=bind,source="$(pwd)"/index.yaml,target=/root/.haros/index.yaml -p 4000:4000 haros_noetic:latest /haros_call.sh https://github.com/ros/ros_tutorials
+```
+
+or
+
+```
+cd path-to-make-haros-easy/docker
+[sudo] docker run -it -v "$(pwd)"/index_ros2.yaml:/root/.haros/index.yaml -p 4000:4000 haros_foxy:latest /haros_call.sh https://github.com/ros2/examples -b foxy
+```
+Open on your browser the page: http://localhost:4000/
+

--- a/docker/foxy/Dockerfile
+++ b/docker/foxy/Dockerfile
@@ -1,0 +1,50 @@
+# Use an official Python runtime as a parent image
+FROM osrf/ros:foxy-desktop
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update && apt upgrade -y && apt-get install -y \
+    cppcheck \
+    cccc \
+    clang-10 \
+    git \
+    libclang-10-dev \
+    python3-pip \
+    llvm-10-dev \
+    wget \
+    netbase \
+    libmagic-dev
+
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/lib/llvm-10/lib
+
+RUN pip3 install --upgrade pip
+RUN pip3 install -Iv clang==10.0.1
+RUN pip3 install -e git+https://github.com/timtadh/pyflwor.git#egg=pyflwor
+RUN pip3 install -e git+https://github.com/git-afsantos/haros.git@dev-py3-support#egg=haros
+RUN pip3 install bonsai-code
+
+RUN apt-get update && apt-get install -y ros-$ROS_DISTRO-desktop && apt upgrade -y
+
+SHELL ["bash", "-c"]
+
+RUN mkdir -p /root/ws/src
+
+# Set the working directory
+WORKDIR .
+
+ENV CMAKE_CXX_COMPILER /usr/lib/llvm-10/bin/clang++
+
+RUN source /opt/ros/$ROS_DISTRO/setup.bash;\
+ cd /root/ws;\
+ colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ;\
+ source /root/ws/install/setup.bash; \
+ haros init
+
+RUN apt-get install -y python-is-python3
+
+COPY haros_call.sh /
+
+EXPOSE 4000
+
+CMD []
+

--- a/docker/haros_call.sh
+++ b/docker/haros_call.sh
@@ -1,0 +1,32 @@
+#/bin/bash
+cd /root/ws/src/
+git clone $1
+
+echo "## Install ROS pkgs dependencies and build ##"
+cd /root/ws
+if [ -n $ROS_VERSION ]
+then
+  if [ $ROS_VERSION == "1" ]
+  then
+    source devel/setup.bash
+    rosdep install -y -i -r --from-path src
+    catkin_make -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+  elif [ $ROS_VERSION == "2" ]
+  then
+    source install/setup.bash
+    rosdep install -y -i -r --from-path src
+    colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+  else
+    echo "ROS version not supported"
+    exit
+  fi
+else
+  echo "ROS installation not found"
+fi
+
+
+echo "## Init HAROS ##"
+haros init
+
+echo "## Call HAROS full analysis ##"
+haros full --server-host 0.0.0.0:4000

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,0 +1,3 @@
+%YAML 1.1
+---
+packages: []

--- a/docker/index_ros2.yaml
+++ b/docker/index_ros2.yaml
@@ -1,0 +1,7 @@
+%YAML 1.1
+---
+
+project: rclcpp_tutorials
+packages:
+    - examples_rclcpp_minimal_publisher
+

--- a/docker/melodic/Dockerfile
+++ b/docker/melodic/Dockerfile
@@ -1,0 +1,49 @@
+# Use an official Python runtime as a parent image
+FROM ros:melodic
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update && apt upgrade -y && apt-get install -y \
+    cppcheck \
+    cccc \
+    clang-10 \
+    git \
+    libclang-10-dev \
+    python-pip \
+    llvm-10-dev \
+    wget \
+    netbase \
+    libmagic-dev
+
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/lib/llvm-10/lib
+
+RUN pip install --upgrade pip
+RUN pip install -Iv clang==10.0.1
+RUN pip install -e git+https://github.com/timtadh/pyflwor.git#egg=pyflwor
+RUN pip install haros
+RUN pip install bonsai-code
+
+RUN apt-get update && apt-get install -y ros-$ROS_DISTRO-desktop
+
+SHELL ["bash", "-c"]
+
+RUN mkdir -p /root/ws/src
+
+# Set the working directory
+WORKDIR .
+
+ENV CMAKE_CXX_COMPILER /usr/lib/llvm-10/bin/clang++
+
+RUN source /opt/ros/$ROS_DISTRO/setup.bash;\
+ cd /root/ws/src;\
+ catkin_init_workspace;\
+ cd /root/ws;\
+ catkin_make -DCMAKE_EXPORT_COMPILE_COMMANDS=1;\
+ source /root/ws/devel/setup.bash; \
+ haros init
+
+COPY haros_call.sh /
+
+EXPOSE 4000
+
+CMD []

--- a/docker/noetic/Dockerfile
+++ b/docker/noetic/Dockerfile
@@ -1,0 +1,49 @@
+# Use an official Python runtime as a parent image
+FROM ros:noetic
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update && apt upgrade -y && apt-get install -y \
+    cppcheck \
+    cccc \
+    clang-10 \
+    git \
+    libclang-10-dev \
+    python3-pip \
+    llvm-10-dev \
+    wget \
+    netbase \
+    libmagic-dev
+
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/lib/llvm-10/lib
+
+RUN pip3 install --upgrade pip
+RUN pip3 install -Iv clang==10.0.1
+RUN pip3 install -e git+https://github.com/timtadh/pyflwor.git#egg=pyflwor
+RUN pip3 install -e git+https://github.com/git-afsantos/haros.git@dev-py3-support#egg=haros
+RUN pip3 install bonsai-code
+
+RUN apt-get update && apt-get install -y ros-$ROS_DISTRO-desktop && apt upgrade -y
+
+SHELL ["bash", "-c"]
+
+RUN mkdir -p /root/ws/src
+
+# Set the working directory
+WORKDIR .
+
+ENV CMAKE_CXX_COMPILER /usr/lib/llvm-10/bin/clang++
+
+RUN source /opt/ros/$ROS_DISTRO/setup.bash;\
+ cd /root/ws/src;\
+ catkin_init_workspace;\
+ cd /root/ws;\
+ catkin_make -DCMAKE_EXPORT_COMPILE_COMMANDS=1;\
+ source /root/ws/devel/setup.bash; \
+ haros init
+
+COPY haros_call.sh /
+
+EXPOSE 4000
+
+CMD []


### PR DESCRIPTION
Related to: https://github.com/git-afsantos/haros/issues/104

I created new docker containers configurations for the different ROS DISTROS, part of the commands of the dockers can be extracted to bash scripts avoiding duplicated commands, for my use case and for debug purposes I kept the full installation and setup of the workspace within the docker file configuration. 

@git-afsantos probably for you will make more sense to call your scripts under https://github.com/git-afsantos/make-haros-easy/tree/main/install instead of run the commands directly.

I added to the README file a couple of examples about how to use the dockers for the analysis.  

P.S. since yesterday I get the following issue for noetic.:

```
  File "/src/haros/haros/extractor.py", line 299, in _populate_packages_and_dependencies
    analysis_ignore = extractor._populate_package(
  File "/src/haros/haros/extractor.py", line 784, in _populate_package
    ignore = source.set_file_stats()
  File "/src/haros/haros/metamodel.py", line 741, in set_file_stats
    for line in handle:
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```

Tt shouldn't be related to the changes proposed in this PR but with an update of the codecs python module. I will check it later and send a separate PR to HAROS.
